### PR TITLE
Support to validate TLS connections against ca_certs files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 launcher.conf
 logfile
 env.v3
+bin/
+include/
+lib64
+lib/
+pyvenv.cfg

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ include/
 lib64
 lib/
 pyvenv.cfg
+*.crt
+*.log

--- a/mqtt-launcher.py
+++ b/mqtt-launcher.py
@@ -149,7 +149,10 @@ if __name__ == '__main__':
         mqttc.username_pw_set(cf.get('mqtt_username'), cf.get('mqtt_password'))
 
     if cf.get('mqtt_tls') is not None:
-        mqttc.tls_set()
+        if cf.get('mqtt_tls_ca') is not None:
+            mqttc.tls_set(ca_certs=cf.get('mqtt_tls_ca'))
+        else:
+            mqttc.tls_set()
 
         if cf.get('mqtt_tls_verify') is not None:
             mqttc.tls_insecure_set(False)

--- a/mqtt-launcher.service
+++ b/mqtt-launcher.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=mqtt-launcher
+After=network.target
+
+[Service]
+PermissionsStartOnly=true
+ExecStart=/bin/bash -c 'source /opt/mqtt-launcher/bin/activate; /opt/mqtt-launcher/mqtt-launcher.py'
+WorkingDirectory=/opt/mqtt-launcher
+StandardOutput=inherit
+StandardError=inherit
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
- added support for the ca_certs option of the SSL connection to avoid disabling ssl verification completely.
- added some files to hte .gitignore file, to avoid, that  files from venv used for testing are included in commits.
- added a sample systemd service file that can be used to start mqtt-launcher as service.

Thank you very much,
Stephan