### PR TITLE
Support merging topic lists across config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,13 @@ must be named the same as the configuration file with a `.d` suffix. Example:
 ├── launcher.conf
 └── launcher.conf.d
     ├── 10-password
-    └── 20-topics
+    ├── 20-topics-common
+    └── 30-topics-local
 ```
+
+If multiple files define their own `topiclist`, they are merged similarly.
+Topics from subsequent files override those with identical names in
+preceding ones.
 
 ## Logging
 

--- a/mqtt-launcher.py
+++ b/mqtt-launcher.py
@@ -42,6 +42,7 @@ import string
 
 qos=2
 CONFIG=os.getenv('MQTTLAUNCHERCONFIG', 'launcher.conf')
+TOPIC_LIST_KEY='topiclist'
 
 class Config(object):
 
@@ -51,8 +52,11 @@ class Config(object):
         conf_files = [filename] + (
             sorted([f for f in conf_dir.iterdir() if f.is_file()]) if conf_dir.is_dir() else []
         )
+        merged_topics = {}
         for conf_file in conf_files:
             exec(compile(open(conf_file, "rb").read(), conf_file, "exec"), self.config)
+            merged_topics.update(self.config.get(TOPIC_LIST_KEY, {}))
+        self.config[TOPIC_LIST_KEY] = merged_topics
 
     def get(self, key, default=None):
         return self.config.get(key, default)
@@ -130,9 +134,9 @@ if __name__ == '__main__':
 
     userdata = {
     }
-    topiclist = cf.get('topiclist')
+    topiclist = cf.get(TOPIC_LIST_KEY)
 
-    if topiclist is None:
+    if not topiclist:
         logging.info("No topic list. Aborting")
         sys.exit(2)
 


### PR DESCRIPTION
Supper merging topic lists across config files such that topics defined in subsequent files override those with identical names in preceding files.